### PR TITLE
Fix trade stream parquet directory creation

### DIFF
--- a/ingest/trade_stream.py
+++ b/ingest/trade_stream.py
@@ -4,6 +4,7 @@ import pandas as pd
 import json
 from datetime import datetime, timezone
 from utils.quote_engine import QuoteEngine
+import os
 
 class Tradestream:
     def __init__(self, symbol: str = "BTC", quote_engine=None):
@@ -11,6 +12,8 @@ class Tradestream:
         # Updated to Hyperliquid WebSocket URL
         self._uri = "wss://api.hyperliquid.xyz/ws"
         self.quote_engine = quote_engine
+        # Ensure trade data directory exists
+        os.makedirs("data/trades", exist_ok=True)
     
     async def load_data(self):
         trades = []


### PR DESCRIPTION
## Summary
- ensure trade storage folder exists when streaming trades

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840e09581608330a4658289ae89d1f2