### PR TITLE
Fix skew_ticks calculation

### DIFF
--- a/ingest/orderbook_stream.py
+++ b/ingest/orderbook_stream.py
@@ -146,6 +146,11 @@ class Orderbookstream:
                         if current_signal_state != "HOLD_CROSSED_SKEW":
                             # Position-aware asymmetric OBI-based risk management
                             current_position = self.quote_engine.get_position()
+                            inventory_deviation = current_position - self.target_inventory
+                            skew_ticks = min(
+                                self.max_inventory_skew_ticks,
+                                abs(inventory_deviation) * self.inventory_tick_skew_per_unit,
+                            )
                             
                             # Asymmetric thresholds based on position
                             # Adjusted condition for larger desired_order_size


### PR DESCRIPTION
## Summary
- compute `skew_ticks` from inventory deviation
- use this value when widening bid/ask prices

## Testing
- `PYTHONPATH=utils pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f4037a1c88330bef15dc6bae3df8a