### PR TITLE
Fix order rate limit tracking and add tests

### DIFF
--- a/tests/test_quote_engine.py
+++ b/tests/test_quote_engine.py
@@ -1,5 +1,7 @@
 import os, sys
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(BASE_DIR)
+sys.path.append(os.path.join(BASE_DIR, "utils"))
 from utils.quote_engine import QuoteEngine
 
 
@@ -11,4 +13,24 @@ def test_same_price_level_true_less_than_half_tick():
 def test_same_price_level_false_when_over_half_tick():
     qe = QuoteEngine()
     assert qe._same_price_level(100.00, 100.006) is False
+
+
+def test_order_rate_limit_blocks_orders():
+    from datetime import datetime, timezone
+
+    qe = QuoteEngine()
+    # Set a very low order rate limit for testing
+    qe.risk_manager.limits.max_orders_per_second = 2
+    qe.risk_manager.order_window_seconds = 1
+
+    orderbook = {
+        "bids": [(100.0, 1.0)],
+        "asks": [(101.0, 1.0)],
+        "timestamp": datetime.now(timezone.utc),
+    }
+
+    assert qe.place_order("buy", 100.0, 0.01, orderbook) is True
+    assert qe.place_order("buy", 100.0, 0.01, orderbook) is True
+    # Third attempt in the same window should be blocked by rate limit
+    assert qe.place_order("buy", 100.0, 0.01, orderbook) is False
 

--- a/utils/quote_engine.py
+++ b/utils/quote_engine.py
@@ -344,7 +344,10 @@ class QuoteEngine:
             return False
 
         mid_price_at_entry = (float(bids[0][0]) + float(asks[0][0])) / 2
-        
+
+        # Record this attempt for order rate limiting
+        self.risk_manager.record_order_attempt()
+
         # Pre-trade risk check
         current_equity = self.mark_to_market(mid_price_at_entry)
         latency_ms = 0.0


### PR DESCRIPTION
## Summary
- record order attempts before running the risk check
- ensure tests use proper import path
- verify rate limit blocks excessive orders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f40521ba48330b69c1f810255b21d