### PR TITLE
Update risk grading to use live emergency status

### DIFF
--- a/tests/test_quote_engine.py
+++ b/tests/test_quote_engine.py
@@ -1,5 +1,7 @@
 import os, sys
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(ROOT_DIR)
+sys.path.append(os.path.join(ROOT_DIR, 'utils'))
 from utils.quote_engine import QuoteEngine
 
 

--- a/tests/test_risk_monitor.py
+++ b/tests/test_risk_monitor.py
@@ -1,0 +1,32 @@
+import os, sys
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+sys.path.append(ROOT_DIR)
+sys.path.append(os.path.join(ROOT_DIR, 'utils'))
+from utils.risk_monitor import RiskMonitor
+
+
+class DummyRiskManager:
+    def __init__(self, emergency=False):
+        self._emergency = emergency
+
+    def emergency_risk_shutdown(self):
+        return self._emergency
+
+
+class DummyQuoteEngine:
+    def __init__(self, emergency=False):
+        self.risk_manager = DummyRiskManager(emergency)
+
+
+def test_risk_grade_no_emergency():
+    qe = DummyQuoteEngine(emergency=False)
+    monitor = RiskMonitor(qe)
+    grade = monitor._calculate_risk_grade({'active_risk_breaches': []}, 0, None)
+    assert grade == 'A'
+
+
+def test_risk_grade_with_emergency():
+    qe = DummyQuoteEngine(emergency=True)
+    monitor = RiskMonitor(qe)
+    grade = monitor._calculate_risk_grade({'active_risk_breaches': []}, 0, None)
+    assert grade == 'C'

--- a/utils/risk_monitor.py
+++ b/utils/risk_monitor.py
@@ -93,7 +93,7 @@ class RiskMonitor:
         score -= active_breaches * 15
         
         # Deduct for emergency conditions
-        if risk_summary.get('emergency_stops', 0) > 0:
+        if self.quote_engine and self.quote_engine.risk_manager.emergency_risk_shutdown():
             score -= 30
         
         # Deduct for excessive O:T ratio


### PR DESCRIPTION
## Summary
- reference risk manager when calculating risk grade
- ensure tests find modules in `utils`
- test emergency stop impact on risk grade

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f404a1f848330b308dada6726cddd