### PR TITLE
Fix OpenSSL build issues

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -55,6 +55,15 @@ set_target_properties(hft_core PROPERTIES
 find_package(Threads REQUIRED)
 target_link_libraries(hft_core PRIVATE Threads::Threads)
 
+# OpenSSL for authenticated websocket connections
+find_package(OpenSSL)
+if(OpenSSL_FOUND)
+    target_link_libraries(hft_core PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    message(STATUS "OpenSSL found - enabling secure WebSocket support")
+else()
+    message(WARNING "OpenSSL not found - WebSocket connections may fail to link")
+endif()
+
 # =============================================================================
 # TESTING SETUP
 # =============================================================================

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -33,7 +33,7 @@ BENCHMARK_EXEC = $(BINDIR)/hft_benchmark
 INCLUDES = -I$(INCDIR)
 
 # Libraries to link
-LIBS = -pthread
+LIBS = -pthread -lssl -lcrypto
 
 # Default target
 .PHONY: all clean debug release test benchmark install


### PR DESCRIPTION
## Summary
- link against OpenSSL in the Makefile and CMake build scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'coinbase')*

------
https://chatgpt.com/codex/tasks/task_e_688531dc88488330bc084191dfba716d